### PR TITLE
Fix exception when run unit test with HtmlUnit webdriver

### DIFF
--- a/arquillian-qunit-impl/src/main/java/org/jboss/arquillian/qunit/pages/QUnitPage.java
+++ b/arquillian-qunit-impl/src/main/java/org/jboss/arquillian/qunit/pages/QUnitPage.java
@@ -41,10 +41,10 @@ import org.openqa.selenium.WebElement;
  */
 public class QUnitPage implements QUnitTestPage {
 
-	@FindBy(jquery = "#qunit-testresult .total")
+	@FindBy(css = "#qunit-testresult .total")
 	WebElement qunitTestResults;
 
-	@FindBy(jquery = "#qunit-tests > li")
+	@FindBy(css = "#qunit-tests > li")
 	List<WebElement> qunitTestsList;
 
 	private static final String moduleNameClassSelector = "module-name";
@@ -118,7 +118,7 @@ public class QUnitPage implements QUnitTestPage {
 					int assertionIndex = 0;
 					for (WebElement assertion : assertions) {
 						final boolean pass = assertion
-								.getAttribute("className").equalsIgnoreCase(
+								.getAttribute("class").equalsIgnoreCase(
 										"pass");
 						final QUnitAssertionImpl assertionDTO = (new QUnitAssertionImpl())
 								.setFailed(!pass)


### PR DESCRIPTION
There are 2 problems:
- htmlunit webdriver doesn't understand webElement.getAttribute("className")
- search by using ByJQuery class will try to enrich the page, but before it try to inject jquery, it throw an JS exception, but htmlUnit will consider this is an fail test --> workaroud: don't use ByJQuery before the test is finished
